### PR TITLE
Override global TOC on the content page itself

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -21,7 +21,7 @@
 			</div>
 
 			
-			{{ if and (gt .WordCount 400 ) (.Site.Params.toc) }}
+			{{ if and (gt .WordCount 400 ) (.Site.Params.toc) (ne .Params.toc false) }}
 			<aside class="toc">
 				<header>
 				<h2>Contents</h2>


### PR DESCRIPTION
Override the TOC on content page itself, with the added benefit that it does not affect current functionality