### PR TITLE
main.js: Fix dark mode when not using Feather

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -6,10 +6,14 @@ function toggleDarkMode() {
         container = document.getElementsByTagName("html")[0];
 
     if (theme === "dark") {
-        toggle.innerHTML = feather.icons.sun.toSvg();
+        if (typeof feather !== "undefined") {
+            toggle.innerHTML = feather.icons.sun.toSvg();
+        }
         container.className = "dark";
     } else {
-        toggle.innerHTML = feather.icons.moon.toSvg();
+        if (typeof feather !== "undefined") {
+            toggle.innerHTML = feather.icons.moon.toSvg();
+        }
         container.className = "";
     }
 }


### PR DESCRIPTION
`toggleDarkMode()` currently fails when it tries to reference one of the Feather icons and we're not using Feather.
This happens if we enable dark mode and any of the following conditions evaluate to false:
```go
(isset .Site.Params "social") (isset .Site.Params "feathericonscdn") (eq .Site.Params.featherIconsCDN true)
```
This PR just adds a check to see if feather is available before updating the dark/light toggle icon.