### PR TITLE
fix: lang.NumFmt deprecation

### DIFF
--- a/layouts/partials/statistics.html
+++ b/layouts/partials/statistics.html
@@ -7,7 +7,7 @@ countwords }}
 {{ $pages := where .Site.RegularPages "Type" "in" .Site.Params.mainSections }}
 
 <h1>Statistics</h1>
-<p><b>{{ $scratch.Get "wordcount" | lang.NumFmt 0 }}</b> words published over {{len $pages }} articles since
+<p><b>{{ $scratch.Get "wordcount" | lang.FormatNumberCustom 0 }}</b> words published over {{len $pages }} articles since
     {{ range last 1 $pages }}
     {{ .Date.Month }} {{ .Date.Year }}.
     {{ end }}
@@ -15,7 +15,7 @@ countwords }}
 {{ $readingMins := div ($scratch.Get "wordcount") .Site.Params.wpm }}
 <p>Reading all that should take you about {{ $readingMins }} minutes
     {{ if gt $readingMins 60 }}
-    (or ~{{div $readingMins 60.0 | lang.NumFmt 1 }} hrs).
+    (or ~{{div $readingMins 60.0 | lang.FormatNumberCustom 1 }} hrs).
     {{else}}
     .
     {{end}}
@@ -23,7 +23,7 @@ countwords }}
 <p>
     For reference, that's about {{div ($scratch.Get "wordcount") (.Site.Params.referenceBookWords | default
     95356.0 ) |
-    lang.NumFmt 1 }}x "{{
+    lang.FormatNumberCustom 1 }}x "{{
     .Site.Params.referenceBook |
     default "The Hobbit"}}" by {{ .Site.Params.referenceAuthor | default "J. R. R. Tolkien"}}.
 </p>


### PR DESCRIPTION
Resolves the following error when running `hugo server -D`

```
hugo v0.133.1+extended darwin/arm64 BuildDate=2024-08-26T13:58:46Z VendorInfo=brew

ERROR deprecated: lang.NumFmt was deprecated in Hugo v0.120.0 and will be removed in Hugo 0.134.0. Use lang.FormatNumberCustom instead.
Built in 535 ms
Error: error building site: logged 1 error(s)
```

Documentation: https://gohugo.io/functions/lang/formatnumbercustom/